### PR TITLE
Text relocations for x86 arch are removed 

### DIFF
--- a/jni/vendor/libjpeg-turbo/Android.mk
+++ b/jni/vendor/libjpeg-turbo/Android.mk
@@ -76,6 +76,8 @@ LOCAL_SRC_FILES += \
 LOCAL_CFLAGS += \
 	-DSIZEOF_SIZE_T=4 \
 
+LOCAL_ASMFLAGS += -DPIC
+
 else ifneq ($(filter $(TARGET_ARCH_ABI), armeabi-v7a armeabi-v7a-hard),)
 LOCAL_SRC_FILES += \
 	$(SOURCE_PATH)/simd/jsimd_arm.c \


### PR DESCRIPTION
Text relocations for x86 arch are removed. There is no text relocations for other archs for now. 
See http://android-developers.blogspot.ru/2016/06/android-changes-for-ndk-developers.html
